### PR TITLE
style: Adjust text color property

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -27,7 +27,7 @@ function	WalletButton(): ReactElement {
 		return (
 			<button
 				onClick={openLoginModal}
-				className={'inline-flex cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 font-mono text-xs font-semibold leading-4 text-neutral-500'}>
+				className={'inline-flex cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-500 bg-neutral-0 px-3 py-2 font-mono text-xs font-semibold leading-4 text-neutral-700'}>
 				<span className={'hidden md:block'}>{'Connect wallet'}</span>
 				<span className={'block md:hidden'}>{'+'}</span>
 			</button>
@@ -37,7 +37,7 @@ function	WalletButton(): ReactElement {
 		<p
 			onClick={onDesactivate}
 			suppressHydrationWarning
-			className={'inline-flex cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 font-mono text-xs font-semibold leading-4 text-neutral-500'}>
+			className={'inline-flex cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-500 bg-neutral-0 px-3 py-2 font-mono text-xs font-semibold leading-4 text-neutral-700'}>
 			<svg
 				className={'mr-0 md:mr-2'}
 				width={'16'}
@@ -77,7 +77,7 @@ function	Navbar(): ReactElement {
 				<div>
 					{router.route !== '/' ? (
 						<Link href={'/'}>
-							<p className={'dashed-underline-gray cursor-pointer font-mono text-xs font-semibold text-neutral-500 transition-all'}>
+							<p className={'dashed-underline-gray cursor-pointer font-mono text-xs font-semibold text-neutral-700 transition-all'}>
 								{'<< Back home'}
 							</p>
 						</Link>
@@ -87,7 +87,7 @@ function	Navbar(): ReactElement {
 					{router.route === '/' ? (
 						<select
 							value={chainID}
-							className={'m-0 mr-2 hidden cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 pr-7 font-mono text-xs font-semibold leading-4 text-neutral-500 md:flex'}
+							className={'m-0 mr-2 hidden cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-500 bg-neutral-0 px-3 py-2 pr-7 font-mono text-xs font-semibold leading-4 text-neutral-700 md:flex'}
 							onChange={(e): void => onSwitchChain(Number(e.target.value), true)}>
 							{Object.values(CHAINS).map((chain, index): ReactElement => (
 								<option key={index} value={chain.chainID}>{chain.name}</option>

--- a/components/VaultActions.tsx
+++ b/components/VaultActions.tsx
@@ -265,9 +265,9 @@ function	VaultAction({vault, vaultData, onUpdateVaultData}: TVaultAction): React
 
 	return (
 		<section aria-label={'ACTIONS'} className={'my-4 mt-8'}>
-			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-700'}>{'APE-IN/OUT'}</h1>
+			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-900'}>{'APE-IN/OUT'}</h1>
 			<div className={vault.VAULT_STATUS === 'withdraw' ? '' : 'hidden'}>
-				<p className={'font-mono text-sm font-medium text-neutral-500'}>{'Deposit closed.'}</p>
+				<p className={'font-mono text-sm font-medium text-neutral-700'}>{'Deposit closed.'}</p>
 			</div>
 
 			{vault.ZAP_ADDR ? (
@@ -275,14 +275,14 @@ function	VaultAction({vault, vaultData, onUpdateVaultData}: TVaultAction): React
 					<div className={vault.VAULT_STATUS === 'withdraw' ? 'hidden' : ''}>
 						<div className={'mb-2 mr-2 flex flex-row items-center'} style={{height: '33px'}}>
 							<input
-								className={'border-neutral-400 bg-neutral-0/0 px-2 py-1.5 font-mono text-xs text-neutral-500'}
+								className={'border-neutral-700 bg-neutral-0/0 px-2 py-1.5 font-mono text-xs text-neutral-700'}
 								style={{height: '33px', backgroundColor: 'rgba(0,0,0,0)'}}
 								type={'text'}
 								value={zapAmount?.normalized}
 								onChange={(e: ChangeEvent<HTMLInputElement>): void => set_zapAmount(
 									handleInputChangeEventValue(e.target.value, vaultData.decimals)
 								)} />
-							<div className={'bg-neutral-50 border border-l-0 border-solid border-neutral-400 px-2 py-1.5 font-mono text-xs text-neutral-400'} style={{height: '33px'}}>
+							<div className={'bg-neutral-50 border border-l-0 border-solid border-neutral-500 px-2 py-1.5 font-mono text-xs text-neutral-700'} style={{height: '33px'}}>
 								{chainCoin}&nbsp;
 							</div>
 						</div>
@@ -320,14 +320,14 @@ function	VaultAction({vault, vaultData, onUpdateVaultData}: TVaultAction): React
 				<div className={vault.VAULT_STATUS === 'withdraw' ? 'hidden' : ''}>
 					<div className={'mb-2 mr-2 flex flex-row items-center'} style={{height: '33px'}}>
 						<input
-							className={'border-neutral-400 bg-neutral-0/0 px-2 py-1.5 font-mono text-xs text-neutral-500'}
+							className={'border-neutral-500 bg-neutral-0/0 px-2 py-1.5 font-mono text-xs text-neutral-700'}
 							style={{height: '33px', backgroundColor: 'rgba(0,0,0,0)'}}
 							type={'text'}
 							value={amount?.normalized}
 							onChange={(e: ChangeEvent<HTMLInputElement>): void => set_amount(
 								handleInputChangeEventValue(e.target.value, vaultData.decimals)
 							)} />
-						<div className={'bg-neutral-50 border border-l-0 border-solid border-neutral-400 px-2 py-1.5 font-mono text-xs text-neutral-400'} style={{height: '33px'}}>
+						<div className={'bg-neutral-50 border border-l-0 border-solid border-neutral-500 px-2 py-1.5 font-mono text-xs text-neutral-700'} style={{height: '33px'}}>
 							{vault.WANT_SYMBOL}
 						</div>
 					</div>

--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -24,9 +24,9 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 		<section aria-label={'DETAILS'}>
 			<div className={'mb-4 font-mono text-sm font-medium'}>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Vault: '}</p>
+					<p className={'inline text-neutral-900'}>{'Vault: '}</p>
 					<a
-						className={'dashed-underline-gray text-neutral-500'}
+						className={'dashed-underline-gray text-neutral-700'}
 						href={`${chainExplorer}/address/${vault.VAULT_ADDR}#code`}
 						target={'_blank'}
 						rel={'noreferrer'}>
@@ -34,38 +34,38 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 					</a>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Version: '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Version: '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>{vaultData.apiVersion}</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{`${vault.WANT_SYMBOL} price (${vault?.PRICE_SOURCE ? vault.PRICE_SOURCE : 'CoinGecko 🦎'}): `}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{`${vault.WANT_SYMBOL} price (${vault?.PRICE_SOURCE ? vault.PRICE_SOURCE : 'CoinGecko 🦎'}): `}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`$${vaultData.wantPrice ? formatAmount(vaultData.wantPrice, vaultData.wantPrice < 10 ? 4 : 2) : '-'}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Deposit Limit: '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Deposit Limit: '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${vaultData.depositLimit.raw.isZero() ? '-' : formatAmount(vaultData?.depositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Total Assets: '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Total Assets: '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${formatAmount(vaultData?.totalAssets.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Total AUM: '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Total AUM: '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`$${vaultData.totalAUM === 0 ? '-' : formatAmount(vaultData.totalAUM, 2)}`}
 						</Suspense>
@@ -74,24 +74,24 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 			</div>
 			<div className={`mb-4 font-mono text-sm font-medium ${vault.VAULT_STATUS === 'withdraw' || vault.CHAIN_ID === 56 ? 'hidden' : ''}`}>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Gross APR (last week): '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Gross APR (last week): '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.week || '-'}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Gross APR (last month): '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Gross APR (last month): '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.month || '-'}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Gross APR (inception): '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Gross APR (inception): '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.inception || '-'}`}
 						</Suspense>
@@ -100,30 +100,30 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 			</div>
 			<div className={'mb-4 font-mono text-sm font-medium text-neutral-700'}>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Price Per Share: '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Price Per Share: '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${vaultData.pricePerShare.normalized}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Available limit: '}</p>
-					<p className={'inline text-neutral-500'}>
+					<p className={'inline text-neutral-900'}>{'Available limit: '}</p>
+					<p className={'inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${formatAmount(vaultData.availableDepositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
 					</p>
 				</div>
 				<div className={'progress-bar'}>
-					<span className={'-ml-2 mr-2 hidden bg-neutral-0 text-neutral-900 md:inline'}>
+					<span className={'-ml-2 mr-2 hidden bg-neutral-0 text-neutral-700 md:inline'}>
 							&nbsp;{'['}&nbsp;
 						<ProgressChart
 							progress={vault.VAULT_STATUS === 'withdraw' ? 1 : vaultData.progress}
 							width={50} />
 							&nbsp;{']'}&nbsp;
 					</span>
-					<span className={'-ml-2 mr-2 inline bg-neutral-0 text-neutral-900 md:hidden'}>
+					<span className={'-ml-2 mr-2 inline bg-neutral-0 text-neutral-700 md:hidden'}>
 							&nbsp;{'['}&nbsp;
 						<ProgressChart
 							progress={vault.VAULT_STATUS === 'withdraw' ? 1 : vaultData.progress}

--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -22,11 +22,11 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 
 	return (
 		<section aria-label={'DETAILS'}>
-			<div className={'mb-4 font-mono text-sm font-medium text-neutral-700'}>
+			<div className={'mb-4 font-mono text-sm font-medium'}>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Vault: '}</p>
+					<p className={'inline text-neutral-700'}>{'Vault: '}</p>
 					<a
-						className={'dashed-underline-gray text-neutral-700'}
+						className={'dashed-underline-gray text-neutral-500'}
 						href={`${chainExplorer}/address/${vault.VAULT_ADDR}#code`}
 						target={'_blank'}
 						rel={'noreferrer'}>
@@ -34,64 +34,64 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 					</a>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Version: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Version: '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>{vaultData.apiVersion}</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{`${vault.WANT_SYMBOL} price (${vault?.PRICE_SOURCE ? vault.PRICE_SOURCE : 'CoinGecko 🦎'}): `}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{`${vault.WANT_SYMBOL} price (${vault?.PRICE_SOURCE ? vault.PRICE_SOURCE : 'CoinGecko 🦎'}): `}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`$${vaultData.wantPrice ? formatAmount(vaultData.wantPrice, vaultData.wantPrice < 10 ? 4 : 2) : '-'}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Deposit Limit: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Deposit Limit: '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${vaultData.depositLimit.raw.isZero() ? '-' : formatAmount(vaultData?.depositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Total Assets: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Total Assets: '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${formatAmount(vaultData?.totalAssets.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Total AUM: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Total AUM: '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`$${vaultData.totalAUM === 0 ? '-' : formatAmount(vaultData.totalAUM, 2)}`}
 						</Suspense>
 					</p>
 				</div>
 			</div>
-			<div className={`mb-4 font-mono text-sm font-medium text-neutral-700 ${vault.VAULT_STATUS === 'withdraw' || vault.CHAIN_ID === 56 ? 'hidden' : ''}`}>
+			<div className={`mb-4 font-mono text-sm font-medium ${vault.VAULT_STATUS === 'withdraw' || vault.CHAIN_ID === 56 ? 'hidden' : ''}`}>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Gross APR (last week): '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Gross APR (last week): '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.week || '-'}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Gross APR (last month): '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Gross APR (last month): '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.month || '-'}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Gross APR (inception): '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Gross APR (inception): '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.inception || '-'}`}
 						</Suspense>
@@ -100,16 +100,16 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 			</div>
 			<div className={'mb-4 font-mono text-sm font-medium text-neutral-700'}>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Price Per Share: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Price Per Share: '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${vaultData.pricePerShare.normalized}`}
 						</Suspense>
 					</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-900'}>{'Available limit: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'inline text-neutral-700'}>{'Available limit: '}</p>
+					<p className={'inline text-neutral-500'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${formatAmount(vaultData.availableDepositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>

--- a/components/VaultStrategies.tsx
+++ b/components/VaultStrategies.tsx
@@ -186,7 +186,7 @@ function	Strategies({vault, onUpdateVaultData}: TStrategies): ReactElement {
 
 	return (
 		<section aria-label={'STRATEGIES'} className={'mt-8'}>
-			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-900'}>{'Strategies'}</h1>
+			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-700'}>{'Strategies'}</h1>
 			{
 				Object.values(strategiesData).map((strategy, index): ReactElement => (
 					<div key={index} className={'mb-4 font-mono text-sm text-neutral-700'}>

--- a/components/VaultStrategies.tsx
+++ b/components/VaultStrategies.tsx
@@ -186,7 +186,7 @@ function	Strategies({vault, onUpdateVaultData}: TStrategies): ReactElement {
 
 	return (
 		<section aria-label={'STRATEGIES'} className={'mt-8'}>
-			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-700'}>{'Strategies'}</h1>
+			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-900'}>{'Strategies'}</h1>
 			{
 				Object.values(strategiesData).map((strategy, index): ReactElement => (
 					<div key={index} className={'mb-4 font-mono text-sm text-neutral-700'}>

--- a/components/VaultWallet.tsx
+++ b/components/VaultWallet.tsx
@@ -13,27 +13,27 @@ function	VaultWallet({vault, vaultData}: {vault: TVault, vaultData: TVaultData})
 
 	return (
 		<section aria-label={'WALLET'} className={'mt-8'}>
-			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-700'}>{'Wallet'}</h1>
-			<div className={'mb-4 font-mono text-sm font-medium text-neutral-500'}>
+			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-900'}>{'Wallet'}</h1>
+			<div className={'mb-4 font-mono text-sm font-medium text-neutral-700'}>
 				<div>
 					<p className={'inline text-neutral-700'}>{'Your Account: '}</p>
-					<p className={'inline font-bold text-neutral-500'}>{ens || `${truncateHex(toAddress(address), 5)}`}</p>
+					<p className={'inline text-neutral-700'}>{ens || `${truncateHex(toAddress(address), 5)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{'Your vault shares: '}</p>
-					<p className={'inline text-neutral-500'}>{`${formatAmount(vaultData?.balanceOf.normalized, 2)}`}</p>
+					<p className={'inline text-neutral-700'}>{`${formatAmount(vaultData?.balanceOf.normalized, 2)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{'Your shares value: '}</p>
-					<p className={'inline text-neutral-500'}>{`${vaultData.balanceOfValue === 0 ? '-' : formatAmount(vaultData?.balanceOfValue, 2)}`}</p>
+					<p className={'inline text-neutral-700'}>{`${vaultData.balanceOfValue === 0 ? '-' : formatAmount(vaultData?.balanceOfValue, 2)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{`Your ${vault.WANT_SYMBOL} Balance: `}</p>
-					<p className={'inline text-neutral-500'}>{`${formatAmount(vaultData?.wantBalance.normalized, 2)}`}</p>
+					<p className={'inline text-neutral-700'}>{`${formatAmount(vaultData?.wantBalance.normalized, 2)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{`Your ${chainCoin} Balance: `}</p>
-					<p className={'inline text-neutral-500'}>{`${formatAmount(vaultData?.coinBalance.normalized, 2)}`}</p>
+					<p className={'inline text-neutral-700'}>{`${formatAmount(vaultData?.coinBalance.normalized, 2)}`}</p>
 				</div>
 			</div>
 		</section>

--- a/components/VaultWrapper.tsx
+++ b/components/VaultWrapper.tsx
@@ -166,10 +166,10 @@ function	VaultWrapper({vault, prices}: {vault: TVault; prices: any;}): ReactElem
 	}, [chainID, networks, prices, provider, vault]);
 
 	return (
-		<div className={'mt-8 text-neutral-500'}>
+		<div className={'mt-8 text-neutral-700'}>
 			<div>
 				<h1 className={'font-mono text-7xl font-semibold leading-120px'}>{vault.LOGO}</h1>
-				<h1 className={'font-mono text-3xl font-semibold text-neutral-700'}>{vault.TITLE}</h1>
+				<h1 className={'font-mono text-3xl font-semibold text-neutral-900'}>{vault.TITLE}</h1>
 			</div>
 			<InfoMessage
 				status={vault.VAULT_STATUS} />

--- a/components/VaultWrapper.tsx
+++ b/components/VaultWrapper.tsx
@@ -168,7 +168,7 @@ function	VaultWrapper({vault, prices}: {vault: TVault; prices: any;}): ReactElem
 	return (
 		<div className={'mt-8 text-neutral-500'}>
 			<div>
-				<h1 className={'font-mono text-7xl font-semibold leading-120px text-neutral-700'}>{vault.LOGO}</h1>
+				<h1 className={'font-mono text-7xl font-semibold leading-120px'}>{vault.LOGO}</h1>
 				<h1 className={'font-mono text-3xl font-semibold text-neutral-700'}>{vault.TITLE}</h1>
 			</div>
 			<InfoMessage

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,7 +34,7 @@ function App(props: AppProps): ReactElement {
 						prices={data}
 						{...pageProps} />
 				</div>
-				<div className={'absolute inset-x-0 bottom-3 flex items-center justify-center font-mono text-xxs text-neutral-500'}>
+				<div className={'absolute inset-x-0 bottom-3 flex items-center justify-center font-mono text-xxs text-neutral-700'}>
 					<a
 						href={'https://twitter.com/ape_tax'}
 						target={'_blank'}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -196,10 +196,10 @@ function	Index(): ReactElement {
 		<main className={'max-w-5xl'}>
 			<div>
 				<div className={'hidden md:block'}>
-					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-700'}>{'Experimental Experiments Registry'}</h1>
+					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
 				</div>
 				<div className={'flex md:hidden'}>
-					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-700'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
+					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
 				</div>
 			</div>
 			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>
@@ -210,7 +210,7 @@ function	Index(): ReactElement {
 			<section aria-label={'TVL & new Vault'} className={'my-8 grid grid-cols-2'}>
 				<div>
 					<div>
-						<span className={'font-mono text-base font-semibold text-neutral-700'}>
+						<span className={'font-mono text-base font-semibold text-neutral-900'}>
 							{`${CHAINS[safeChainID]?.displayName || 'Chain'} TVL:`}
 						</span>
 						<span className={'font-mono text-base font-normal text-neutral-700'}>
@@ -223,7 +223,7 @@ function	Index(): ReactElement {
 							<span className={'font-mono font-semibold text-neutral-700'}>
 								{'Endorsed:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-500'}>
+							<span className={'font-mono font-normal text-neutral-700'}>
 								{` $${formatAmount(tvl?.tvlEndorsed, 2)}`}
 							</span>
 						</div>
@@ -231,7 +231,7 @@ function	Index(): ReactElement {
 							<span className={'font-mono font-semibold text-neutral-700'}>
 								{'Experimental:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-500'}>
+							<span className={'font-mono font-normal text-neutral-700'}>
 								{` $${formatAmount(tvl?.tvlExperimental, 2)}`}
 							</span>
 						</div>
@@ -239,7 +239,7 @@ function	Index(): ReactElement {
 							<span className={'font-mono font-semibold text-neutral-700'}>
 								{'Deprecated:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-500'}>
+							<span className={'font-mono font-normal text-neutral-700'}>
 								{` $${formatAmount(tvl?.tvlDeprecated, 2)}`}
 							</span>
 						</div>
@@ -256,7 +256,7 @@ function	Index(): ReactElement {
 
 			<div className={'grid max-w-5xl grid-cols-2 gap-2'}>
 				<div className={'col-span-2 mb-4 w-full md:col-span-1'}>
-					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-700'}>{'🚀 Experimental'}</h2>
+					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-900'}>{'🚀 Experimental'}</h2>
 					<ul>
 						{vaultsActiveExperimental?.map((vault): ReactElement => (
 							<li key={vault.VAULT_SLUG} className={'cursor-pointer'}>
@@ -269,7 +269,7 @@ function	Index(): ReactElement {
 												))
 											}
 										</span>
-										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-500'}>
+										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
 											{vault.TITLE}
 										</span>
 										<Tag status={vault.VAULT_STATUS} />
@@ -281,7 +281,7 @@ function	Index(): ReactElement {
 				</div>
 
 				<div className={'col-span-2 mb-4 w-full md:col-span-1'}>
-					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-700'}>{'🧠 Weird'}</h2>
+					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-900'}>{'🧠 Weird'}</h2>
 					<ul>
 						{vaultsActiveWeird?.map((vault): ReactElement => (
 							<li key={vault.VAULT_SLUG} className={'cursor-pointer'}>
@@ -294,7 +294,7 @@ function	Index(): ReactElement {
 												))
 											}
 										</span>
-										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-500'}>
+										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
 											{vault.TITLE}
 										</span>
 										<Tag status={vault.VAULT_STATUS} />
@@ -304,7 +304,7 @@ function	Index(): ReactElement {
 						))}
 					</ul>
 
-					<h2 className={'mb-4 mt-12 font-mono text-2xl font-semibold text-neutral-700'}>{'🦍 Community'}</h2>
+					<h2 className={'mb-4 mt-12 font-mono text-2xl font-semibold text-neutral-900'}>{'🦍 Community'}</h2>
 					<ul>
 						{(communityVaults || [])?.map((vault: TVault): ReactElement => (
 							<li key={vault.VAULT_ADDR} className={'cursor-pointer'}>
@@ -313,7 +313,7 @@ function	Index(): ReactElement {
 										<span className={'flex flex-row items-center'}>
 											{'🦍🦍'}
 										</span>
-										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-500'}>
+										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
 											{vault.SYMBOL || ''}
 										</span>
 									</div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -223,7 +223,7 @@ function	Index(): ReactElement {
 							<span className={'font-mono font-semibold text-neutral-700'}>
 								{'Endorsed:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-700'}>
+							<span className={'font-mono font-normal text-neutral-500'}>
 								{` $${formatAmount(tvl?.tvlEndorsed, 2)}`}
 							</span>
 						</div>
@@ -231,7 +231,7 @@ function	Index(): ReactElement {
 							<span className={'font-mono font-semibold text-neutral-700'}>
 								{'Experimental:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-700'}>
+							<span className={'font-mono font-normal text-neutral-500'}>
 								{` $${formatAmount(tvl?.tvlExperimental, 2)}`}
 							</span>
 						</div>
@@ -239,7 +239,7 @@ function	Index(): ReactElement {
 							<span className={'font-mono font-semibold text-neutral-700'}>
 								{'Deprecated:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-700'}>
+							<span className={'font-mono font-normal text-neutral-500'}>
 								{` $${formatAmount(tvl?.tvlDeprecated, 2)}`}
 							</span>
 						</div>

--- a/pages/newVault.tsx
+++ b/pages/newVault.tsx
@@ -35,7 +35,7 @@ function ComboBox({selectedGauge, set_selectedGauge}: {selectedGauge: Maybe<TGau
 			<div className={'relative'}>
 				<div className={'w-full'}>
 					<Combobox.Input
-						className={'w-full border-neutral-400 bg-white/0 px-2 py-1.5 font-mono text-neutral-500 focus:border-neutral-700 focus:ring-0 active:ring-0'}
+						className={'w-full border-neutral-500 bg-white/0 px-2 py-1.5 font-mono text-neutral-700 focus:border-neutral-700 focus:ring-0 active:ring-0'}
 						displayValue={(gauge): any => (gauge as TGauge)?.address}
 						onChange={(event): void => set_query(event.target.value)}
 					/>
@@ -45,7 +45,7 @@ function ComboBox({selectedGauge, set_selectedGauge}: {selectedGauge: Maybe<TGau
 							viewBox={'0 0 20 20'}
 							fill={'currentColor'}
 							aria-hidden={'true'}
-							className={'h-5 w-5 text-neutral-500'}>
+							className={'h-5 w-5 text-neutral-700'}>
 							<path
 								fillRule={'evenodd'}
 								d={'M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z'}
@@ -60,22 +60,22 @@ function ComboBox({selectedGauge, set_selectedGauge}: {selectedGauge: Maybe<TGau
 					leaveFrom={'opacity-100'}
 					leaveTo={'opacity-0'}
 					afterLeave={(): void => set_query('')}>
-					<Combobox.Options className={'absolute mt-1 max-h-60 w-full overflow-auto border border-neutral-400 bg-neutral-0 py-1 text-base focus:outline-none'}>
+					<Combobox.Options className={'absolute mt-1 max-h-60 w-full overflow-auto border border-neutral-500 bg-neutral-0 py-1 text-base focus:outline-none'}>
 						{!filteredGauges || (filteredGauges || [])?.length === 0 && query !== '' ? (
-							<div className={'relative cursor-default select-none px-4 py-2 text-neutral-500'}>
+							<div className={'relative cursor-default select-none px-4 py-2 text-neutral-700'}>
 								{'Nothing found.'}
 							</div>
 						) : (
 							(filteredGauges || []).map((gauge): ReactElement => (
 								<Combobox.Option
 									key={gauge.address}
-									className={({active}): string => `relative cursor-pointer select-none py-2 px-4 ${active ? 'bg-neutral-100 text-neutral-700' : 'text-neutral-500'}`}
+									className={({active}): string => `relative cursor-pointer select-none py-2 px-4 ${active ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-700'}`}
 									value={gauge}>
 									{({selected}): ReactElement => (
 										<>
 											<div className={`block truncate ${selected ? 'font-semibold' : 'font-normal'}`}>
 												<p className={'text-base tabular-nums text-neutral-700'}>{gauge.address}</p>
-												<p className={'text-sm text-neutral-500'}>{gauge.name}</p>
+												<p className={'text-sm text-neutral-700'}>{gauge.name}</p>
 											</div>
 										</>
 									)}
@@ -171,7 +171,7 @@ function	Index(): ReactElement {
 	if (!isActive) {
 		return (
 			<section>
-				<h1 className={'font-mono text-sm font-semibold text-neutral-700'}>{'Not connected to Ex'}<sup>{'2'}</sup>{' 🧪'}</h1>
+				<h1 className={'font-mono text-sm font-semibold text-neutral-900'}>{'Not connected to Ex'}<sup>{'2'}</sup>{' 🧪'}</h1>
 			</section>
 		);
 	}
@@ -180,10 +180,10 @@ function	Index(): ReactElement {
 		<main className={'mt-8 max-w-5xl'}>
 			<div>
 				<div className={'hidden md:block'}>
-					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-700'}>{'Experimental Experiments Registry'}</h1>
+					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
 				</div>
 				<div className={'flex md:hidden'}>
-					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-700'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
+					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
 				</div>
 			</div>
 			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>
@@ -193,7 +193,7 @@ function	Index(): ReactElement {
 			<section aria-label={'New Vault'} className={'my-8 grid grid-cols-1'}>
 				<div className={'mx-auto w-full border border-dashed border-neutral-500 p-4'}>
 					<div>
-						<p className={'font-mono text-3xl font-semibold text-neutral-700'}>
+						<p className={'font-mono text-3xl font-semibold text-neutral-900'}>
 							{'Add New Vault'}
 						</p>
 					</div>
@@ -207,29 +207,29 @@ function	Index(): ReactElement {
 
 					<div>
 						<div className={'mb-6 mt-12 flex flex-col space-y-2'}>
-							<label className={'-mb-1 text-xs font-semibold text-neutral-500'}>{'Gauge Address'}</label>
+							<label className={'-mb-1 text-xs font-semibold text-neutral-700'}>{'Gauge Address'}</label>
 							<ComboBox selectedGauge={selectedGauge} set_selectedGauge={set_selectedGauge} />
 						</div>
 						<div className={'mb-12 flex flex-col space-y-3'}>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-500'}>{'Vault Name'}</label>
-								<p className={'font-mono text-neutral-500'}>
+								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Name'}</label>
+								<p className={'font-mono text-neutral-700'}>
 									{gaugeInfo.exists ? `Balancer ${gaugeInfo.symbol} Auto-Compounding yVault` : '-'}
 								</p>
 							</div>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-500'}>{'Vault Symbol'}</label>
-								<p className={'font-mono text-neutral-500'}>
+								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Symbol'}</label>
+								<p className={'font-mono text-neutral-700'}>
 									{gaugeInfo.exists ? `yvBlp${gaugeInfo.symbol}` : '-'}
 								</p>
 							</div>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-500'}>{'Vault Address'}</label>
+								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Address'}</label>
 								{gaugeInfo.deployed ? <AddressWithActions
 									explorer={'https://etherscan.io'}
-									className={'font-mono font-normal text-neutral-500'}
+									className={'font-mono font-normal text-neutral-700'}
 									address={toAddress(gaugeInfo.vaultAddress)}
-									truncate={0} /> : <p className={'h-8 font-mono text-neutral-500'}>{'-'}</p>
+									truncate={0} /> : <p className={'h-8 font-mono text-neutral-700'}>{'-'}</p>
 								}
 							</div>
 						</div>

--- a/pages/newVault.tsx
+++ b/pages/newVault.tsx
@@ -207,24 +207,24 @@ function	Index(): ReactElement {
 
 					<div>
 						<div className={'mb-6 mt-12 flex flex-col space-y-2'}>
-							<label className={'-mb-1 text-xs font-semibold text-neutral-700/60'}>{'Gauge Address'}</label>
+							<label className={'-mb-1 text-xs font-semibold text-neutral-500'}>{'Gauge Address'}</label>
 							<ComboBox selectedGauge={selectedGauge} set_selectedGauge={set_selectedGauge} />
 						</div>
 						<div className={'mb-12 flex flex-col space-y-3'}>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-700/60'}>{'Vault Name'}</label>
+								<label className={'text-xs font-semibold text-neutral-500'}>{'Vault Name'}</label>
 								<p className={'font-mono text-neutral-500'}>
 									{gaugeInfo.exists ? `Balancer ${gaugeInfo.symbol} Auto-Compounding yVault` : '-'}
 								</p>
 							</div>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-700/60'}>{'Vault Symbol'}</label>
+								<label className={'text-xs font-semibold text-neutral-500'}>{'Vault Symbol'}</label>
 								<p className={'font-mono text-neutral-500'}>
 									{gaugeInfo.exists ? `yvBlp${gaugeInfo.symbol}` : '-'}
 								</p>
 							</div>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-700/60'}>{'Vault Address'}</label>
+								<label className={'text-xs font-semibold text-neutral-500'}>{'Vault Address'}</label>
 								{gaugeInfo.deployed ? <AddressWithActions
 									explorer={'https://etherscan.io'}
 									className={'font-mono font-normal text-neutral-500'}
@@ -236,7 +236,7 @@ function	Index(): ReactElement {
 						<button
 							onClick={onCreateVault}
 							disabled={!selectedGauge || isZeroAddress(selectedGauge.address) || !!error || txStatusCreateVault.pending}
-							className={`${!selectedGauge || isZeroAddress(selectedGauge.address) || !!error ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-2 w-full border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold text-neutral-900 transition-colors`}>
+							className={`${!selectedGauge || isZeroAddress(selectedGauge.address) || !!error ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-2 w-full border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold text-neutral-700 transition-colors`}>
 							{error ? '❌ A vault already exists for this gauge' : '🤯 Create your own Vault'}
 						</button>
 					</div>


### PR DESCRIPTION
## Description

Currently, the repo has some sections where it's not possible to differentiate between labels and data. This happens because there is not enough contrast in the color of the texts which makes it difficult to identify the different types of content.

## Motivation and Context

The intention after applying color changes to some parts of the content is to make it easier and more comfortable to read the information.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected.